### PR TITLE
Corrige erro em buscas no Acre

### DIFF
--- a/projects/ngx-viacep/src/lib/ngx-viacep.service.ts
+++ b/projects/ngx-viacep/src/lib/ngx-viacep.service.ts
@@ -58,7 +58,7 @@ export class NgxViacepService {
 
   private static ufExists(uf: string): boolean {
 
-    return VALID_UFS.indexOf(uf.toLocaleUpperCase()) > 0;
+    return VALID_UFS.indexOf(uf.toLocaleUpperCase()) > -1;
   }
 
   private static validateState(province: string): void {


### PR DESCRIPTION
Esse pequeno typo impedia a pesquisa de CEPs localizados no Acre. 
Suponho que fosse um meme, perdão aeuehauaeh